### PR TITLE
fix: add pyproject.toml to cap setuptools<82 in isolated build venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<82", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary

- setuptools 82.0.0 removed `pkg_resources`
- When Poetry 1.8.5 builds this package from source as a git dependency, it creates an isolated build venv and resolves the latest setuptools (82.x), causing `ModuleNotFoundError: No module named 'pkg_resources'` before installation begins
- Add a minimal `pyproject.toml` declaring `[build-system].requires = ["setuptools<82", "wheel"]` — this is read by the build frontend *before* the build venv is created, so it caps setuptools at the right point
- No changes to `setup.py` or any existing code

## Why pyproject.toml and not requirements.txt or setup_requires?

- `requirements.txt` is runtime deps — never consulted during the isolated build step
- `setup_requires` inside `setup()` is a legacy mechanism ignored by PEP 517 isolated builds (the venv is already built before `setup.py` runs)
- `[build-system].requires` in `pyproject.toml` is the correct PEP 517/518 place to declare build-time dependencies

## Test plan

- [ ] `pip install --no-deps .` succeeds on a venv with `setuptools>=82`