### PR TITLE
fix: pin runtime dependencies to known-good versions

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,8 +1,8 @@
-addict
-matplotlib
-numpy
-pyyaml
+addict==2.4.0
+matplotlib==3.10.3
+numpy==1.26.4
+pyyaml==6.0.2
 regex;sys_platform=='win32'
-rich
-termcolor
-yapf
+rich==14.0.0
+termcolor==3.1.0
+yapf==0.40.1


### PR DESCRIPTION
Pin all direct runtime dependencies.